### PR TITLE
Add qBittorrent API key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,12 @@ services:
       QBITTORRENT_HOST: gluetun
       QBITTORRENT_HTTPS: false
       QBITTORRENT_PORT: 8080
-      QBITTORRENT_USER: admin
-      QBITTORRENT_PASS: adminadmin
+      # Recommended: API key auth (qBittorrent v5+).
+      # If set, username/password below are ignored entirely.
+      QBITTORRENT_API_KEY: 'qbt_xxxx'
+      # Alternative: username/password (comment out API key above if using user auth)
+      # QBITTORRENT_USER: admin
+      # QBITTORRENT_PASS: adminadmin
       # gluetun settings
       GLUETUN_HOST: gluetun
       GLUETUN_AUTH_TYPE: apikey
@@ -177,6 +181,16 @@ services:
 > **HTTPS and SSL Certificates**: When using `QBITTORRENT_HTTPS: true`, qSticky defaults to accepting self-signed certificates (`QBITTORRENT_VERIFY_SSL: false`). Set `QBITTORRENT_VERIFY_SSL: true` if you want strict SSL certificate verification.
 
 ## qBittorrent Setup
+
+qSticky supports two mutually exclusive authentication methods for qBittorrent:
+
+| Method | Variables | Notes |
+|--------|-----------|-------|
+| **API key** *(recommended)* | `QBITTORRENT_API_KEY` | qBittorrent v5+. Stateless Bearer token. |
+| Username / password | `QBITTORRENT_USER` + `QBITTORRENT_PASS` | Session-cookie based.|
+
+> [!TIP]
+> **Use the API key where possible.** If `QBITTORRENT_API_KEY` is set, it is used exclusively, qSticky will **not** fall back to username/password if the key is rejected. Generate a key in qBittorrent → Preferences → WebUI → API Key (requires qBittorrent v5+).
 
 qBittorrent can be deployed like the following example:
 ```yaml
@@ -262,8 +276,12 @@ services:
       QBITTORRENT_HOST: gluetun
       QBITTORRENT_HTTPS: false
       QBITTORRENT_PORT: 8080
-      QBITTORRENT_USER: admin
-      QBITTORRENT_PASS: 'YOURPASS'
+      # Recommended: API key auth (qBittorrent v5+).
+      # If set, username/password below are ignored entirely.
+      QBITTORRENT_API_KEY: 'qbt_xxxx'
+      # Alternative: username/password (comment out API key above if using user auth)
+      # QBITTORRENT_USER: admin
+      # QBITTORRENT_PASS: 'YOURPASS'
       # gluetun settings
       GLUETUN_HOST: gluetun
       GLUETUN_AUTH_TYPE: apikey
@@ -286,8 +304,9 @@ All configuration is done through environment variables:
 |---------------------|-------------|---------|
 | QBITTORRENT_HOST | qBittorrent server hostname | gluetun |
 | QBITTORRENT_PORT | qBittorrent server port | 8080 |
-| QBITTORRENT_USER | qBittorrent username | admin |
-| QBITTORRENT_PASS | qBittorrent password | adminadmin |
+| QBITTORRENT_USER | qBittorrent username (used only when `QBITTORRENT_API_KEY` is not set) | admin |
+| QBITTORRENT_PASS | qBittorrent password (used only when `QBITTORRENT_API_KEY` is not set) | adminadmin |
+| QBITTORRENT_API_KEY | qBittorrent API key (v5+). When set, used exclusively | "" |
 | QBITTORRENT_HTTPS | Use HTTPS for qBittorrent connection | false |
 | QBITTORRENT_VERIFY_SSL | Verify SSL certificates for HTTPS connections | false |
 | CHECK_INTERVAL | API check interval in seconds | 30 |
@@ -320,6 +339,7 @@ When successful, the logs will look something like:
 
 ```bash
 qsticky - INFO - Starting qSticky port manager...
+qsticky - INFO - qBittorrent auth: API key
 qsticky - INFO - Port change needed: 54219 -> 45720
 qsticky - INFO - Successfully updated port to 45720
 qsticky - INFO - Initial status - Gluetun: ✓, qBit: ✓, Port: 45720

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,12 @@ services:
       QBITTORRENT_HOST: gluetun
       QBITTORRENT_HTTPS: false
       QBITTORRENT_PORT: 8080
-      QBITTORRENT_USER: admin
-      QBITTORRENT_PASS: 'YOURPASS'
+      # Recommended: API key auth (qBittorrent v5+).
+      # If set, username/password below are ignored entirely.
+      QBITTORRENT_API_KEY: 'qbt_xxxx'
+      # Alternative: username/password (comment out API key above if using user auth)
+      # QBITTORRENT_USER: admin
+      # QBITTORRENT_PASS: 'YOURPASS'
       # gluetun settings
       GLUETUN_HOST: gluetun
       GLUETUN_AUTH_TYPE: apikey

--- a/qsticky/config.py
+++ b/qsticky/config.py
@@ -32,6 +32,13 @@ class Settings(BaseSettings):
         description="Verify SSL certificates for qBittorrent"
     )] = False
 
+    qbittorrent_api_key: Annotated[str, Field(
+        description=(
+            "qBittorrent API key (v5+)."
+            "Generate via qBittorrent Preferences → WebUI → API Key."
+        )
+    )] = ""
+
     check_interval: Annotated[int, Field(
         description="Interval in seconds between port checks"
     )] = 30

--- a/qsticky/manager.py
+++ b/qsticky/manager.py
@@ -97,6 +97,11 @@ class PortManager:
         else:
             self.logger.info("Starting qSticky port manager...")
 
+        if self.qbit._use_api_key:
+            self.logger.info("qBittorrent auth: API key")
+        else:
+            self.logger.info("qBittorrent auth: username/password")
+
         while not self.shutdown_event.is_set():
             try:
                 await self.handle_port_change()

--- a/qsticky/qbittorrent.py
+++ b/qsticky/qbittorrent.py
@@ -24,6 +24,9 @@ class QBittorrentClient:
         )
         self._logged_in_once = False
         self.last_login_failed = False
+        self._use_api_key = bool(settings.qbittorrent_api_key)
+        if self._use_api_key:
+            self._validate_api_key(settings.qbittorrent_api_key)
         self._use_unsafe_cookie_jar = self._is_ip_address(settings.qbittorrent_host)
 
     def _is_ip_address(self, host: str) -> bool:
@@ -32,6 +35,19 @@ class QBittorrentClient:
             return True
         except ValueError:
             return False
+
+    def _validate_api_key(self, key: str) -> None:
+        # qBittorrent v5+ requires the key to be exactly 32 chars - "qbt_" + 28 alphanumeric characters.
+        valid = (
+            len(key) == 32
+            and key.startswith("qbt_")
+            and key[4:].isalnum()
+        )
+        if not valid:
+            self.logger.warning(
+                "QBITTORRENT_API_KEY does not match the required format "
+                "Generate a valid key via qBittorrent Preferences → WebUI → API Key."
+            )
 
     def _get_cookie_jar(self) -> Optional[aiohttp.CookieJar]:
         if not self._use_unsafe_cookie_jar:
@@ -78,6 +94,8 @@ class QBittorrentClient:
         self.authenticated = False
 
     async def _ensure_login(self) -> bool:
+        if self._use_api_key:
+            return True
         await self._init_session()
         if self.authenticated:
             return True
@@ -136,6 +154,64 @@ class QBittorrentClient:
         retry: bool = True,
         **kwargs: Any
     ) -> tuple[Optional[int], Optional[str]]:
+        if self._use_api_key:
+            return await self._request_with_api_key(method, path, retry=retry, **kwargs)
+        return await self._request_with_session(method, path, retry=retry, **kwargs)
+
+    async def _request_with_api_key(
+        self,
+        method: str,
+        path: str,
+        *,
+        retry: bool = True,
+        **kwargs: Any
+    ) -> tuple[Optional[int], Optional[str]]:
+        headers = kwargs.pop("headers", {})
+        headers["Authorization"] = f"Bearer {self.settings.qbittorrent_api_key}"
+        kwargs["headers"] = headers
+
+        ssl_context = None
+        if self.settings.qbittorrent_https and not self.settings.qbittorrent_verify_ssl:
+            ssl_context = ssl.create_default_context()
+            ssl_context.check_hostname = False
+            ssl_context.verify_mode = ssl.CERT_NONE
+
+        try:
+            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            async with aiohttp.ClientSession(connector=connector) as session:
+                async with session.request(
+                    method,
+                    f"{self.base_url}{path}",
+                    **kwargs
+                ) as response:
+                    content = await response.text()
+
+                    if response.status == 401:
+                        self.logger.error(
+                            "qBittorrent API key rejected (HTTP 401) - check QBITTORRENT_API_KEY"
+                        )
+                        self.health_status.healthy = False
+                        self.health_status.last_error = "API key auth failed (HTTP 401)"
+                        return response.status, content
+
+                    return response.status, content
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            if retry:
+                self.logger.warning(
+                    f"qBittorrent request to {path} failed: {str(e)}, retrying once"
+                )
+                return await self._request_with_api_key(method, path, retry=False, **kwargs)
+            self.logger.error(f"qBittorrent request to {path} failed: {str(e)}")
+            return None, None
+
+    async def _request_with_session(
+        self,
+        method: str,
+        path: str,
+        *,
+        retry: bool = True,
+        **kwargs: Any
+    ) -> tuple[Optional[int], Optional[str]]:
         if not await self._ensure_login():
             return None, None
 
@@ -148,13 +224,13 @@ class QBittorrentClient:
                 content = await response.text()
 
                 # 403 = session expired, recreate and retry.
-                # 401 on ≥5.2.0 = bad cred
+                # 401 on v5+ = bad cred, no retry.
                 if response.status == 403 and retry:
                     self.logger.warning(
                         f"qBittorrent request to {path} returned {response.status}, recreating session"
                     )
                     await self.reset_session()
-                    return await self.request(method, path, retry=False, **kwargs)
+                    return await self._request_with_session(method, path, retry=False, **kwargs)
 
                 return response.status, content
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
@@ -163,7 +239,7 @@ class QBittorrentClient:
                     f"qBittorrent request to {path} failed: {str(e)}, recreating session"
                 )
                 await self.reset_session()
-                return await self.request(method, path, retry=False, **kwargs)
+                return await self._request_with_session(method, path, retry=False, **kwargs)
 
             self.logger.error(f"qBittorrent request to {path} failed: {str(e)}")
             return None, None


### PR DESCRIPTION
Adds support for authenticating to the qBittorrent Web API with an API key, as well as config and logging updates. Updated Dockerfile, docker-compose.yml, and README to reflect this. 

API key usage tested and is now the recommended method of auth. 