### PR TITLE
Feat: Docker Secrets

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Build and Push Multi-Arch Image
 on:
   workflow_dispatch:
   push:
-    branches: [ main, dev, qbit-session, feat/docker-secrets ]
+    branches: [ main, dev, qbit-session, feat/*, fix/*, hotfix/* ]
     tags:
       - 'v*'
 

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Build and Push Multi-Arch Image
 on:
   workflow_dispatch:
   push:
-    branches: [ main, dev, qbit-session ]
+    branches: [ main, dev, qbit-session, feat/docker-secrets ]
     tags:
       - 'v*'
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,37 @@ All configuration is done through environment variables:
 | GLUETUN_PASSWORD | Gluetun basic auth password | "" |
 | GLUETUN_APIKEY | Gluetun API key | "" |
 
+## Docker Secrets
+
+You may use [Docker secrets](https://docs.docker.com/compose/how-tos/use-secrets/) to store sensitive credentials. Environment variables take precedence if both are set.
+
+Secret file names must match the lowercase field names below:
+
+| Secret name | Replaces env var |
+|---|---|
+| `qbittorrent_user` | `QBITTORRENT_USER` |
+| `qbittorrent_pass` | `QBITTORRENT_PASS` |
+| `qbittorrent_api_key` | `QBITTORRENT_API_KEY` |
+| `gluetun_username` | `GLUETUN_USERNAME` |
+| `gluetun_password` | `GLUETUN_PASSWORD` |
+| `gluetun_apikey` | `GLUETUN_APIKEY` |
+
+### Example
+
+```yaml
+secrets:
+  qbittorrent_api_key:
+    file: ./secrets/qbittorrent_api_key.txt
+  gluetun_apikey:
+    file: ./secrets/gluetun_apikey.txt
+
+services:
+  qsticky:
+    ... # qsticky config ... #
+```
+
+Each secret file should contain only the secret value.
+
 ## Verification
 
 To verify qSticky is working:

--- a/qsticky/config.py
+++ b/qsticky/config.py
@@ -72,7 +72,7 @@ class Settings(BaseSettings):
         description="Gluetun API key"
     )] = ""
 
-    model_config = ConfigDict(env_prefix="")
+    model_config = ConfigDict(env_prefix="", secrets_dir="/run/secrets")
 
 
 @dataclass


### PR DESCRIPTION
Adds support for supplying sensitive credentials (API keys, passwords) via Docker secrets instead of plaintext environment variables, resolving #106.

Uses pydantic-settings' built-in `secrets_dir`.

Also extends CI to build on feat/*, fix/*, and hotfix/* branches.